### PR TITLE
FIx Endlessloop if connection lost 

### DIFF
--- a/src/snap_sysutils.php
+++ b/src/snap_sysutils.php
@@ -7,7 +7,8 @@
 
 //---------------------------------------------------------------------------
 function SysGetTick() {
-  return (int)(microtime(true) / 1000.0);
+	// Returns it in seconds as float with micosecond precision. We need ms here to compare to timeout ms. So multiply by 1000.
+  	return (int)(microtime(true) * 1000.0);
 }
 //---------------------------------------------------------------------------
 function SysSleep($Delay_ms) {


### PR DESCRIPTION
Returns it in seconds as float with microsecond precision. We need ms here to compare to timeout ms. So multiply by 1000.

Before it was the number of thousand seconds since Unix.

Waiting (WaitForData() ) for a delta of 3000 (timeout) resulted to wait for 3000 000 seconds (practical infinite loop), now it's 3000ms.

Now a connection times out.

Did not test for side effects, only looked fast over it, but they are now also in ms not thousand seconds since Unix.
